### PR TITLE
recvmsg_initialized: keep addr.len correct with MsgHdrInit

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -803,7 +803,7 @@ impl<'name, 'bufs, 'control> fmt::Debug for MsgHdrMut<'name, 'bufs, 'control> {
 pub struct MsgHdrInit<'addr, 'bufs, 'control> {
     inner: sys::msghdr,
 
-    /// This is a walkaround for a subtle problem:
+    /// This is a workaround for a subtle problem:
     ///
     /// `sys::msghdr` does not store the full `SockAddr`, namely only `sockaddr_storage`,
     /// not the `len`. Any syscall that operates on `MsgHdrInit` does not update
@@ -889,7 +889,9 @@ impl<'addr, 'bufs, 'control> MsgHdrInit<'addr, 'bufs, 'control> {
         cmsg_vec
     }
 
-    /// Returns the optional source address in this struct.
+    /// Returns the optional source address in the msg.
+    ///
+    /// This refers to the same address passed in [`Self::with_addr`]
     pub fn get_addr(&self) -> Option<&SockAddr> {
         self.src.as_deref()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -809,8 +809,6 @@ pub struct MsgHdrInit<'addr, 'bufs, 'control> {
     /// not the `len`. Any syscall that operates on `MsgHdrInit` does not update
     /// `addr.len` in the struct passed in via `with_addr`. Hence we store a reference
     /// here to access both the storage and the len.
-    ///
-    /// This problem will be gone if `SockAddr` struct removes its `len` field.
     src: Option<&'addr mut SockAddr>,
 
     _lifetimes: PhantomData<(&'bufs [IoSliceMut<'bufs>], &'control [u8])>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -889,7 +889,7 @@ impl<'addr, 'bufs, 'control> MsgHdrInit<'addr, 'bufs, 'control> {
 
     /// Returns the optional source address in the msg.
     ///
-    /// This refers to the same address passed in [`Self::with_addr`]
+    /// This is a convenient method to access the address passed in [`Self::with_addr`]
     pub fn get_addr(&self) -> Option<&SockAddr> {
         self.src.as_deref()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -802,7 +802,18 @@ impl<'name, 'bufs, 'control> fmt::Debug for MsgHdrMut<'name, 'bufs, 'control> {
 )))]
 pub struct MsgHdrInit<'addr, 'bufs, 'control> {
     inner: sys::msghdr,
-    _lifetimes: PhantomData<(&'addr SockAddr, &'bufs [IoSliceMut<'bufs>], &'control [u8])>,
+
+    /// This is a walkaround for a subtle problem:
+    ///
+    /// `sys::msghdr` does not store the full `SockAddr`, namely only `sockaddr_storage`,
+    /// not the `len`. Any syscall that operates on `MsgHdrInit` does not update
+    /// `addr.len` in the struct passed in via `with_addr`. Hence we store a reference
+    /// here to access both the storage and the len.
+    ///
+    /// This problem will be gone if `SockAddr` struct removes its `len` field.
+    src: Option<&'addr mut SockAddr>,
+
+    _lifetimes: PhantomData<(&'bufs [IoSliceMut<'bufs>], &'control [u8])>,
 }
 
 #[cfg(not(any(
@@ -819,6 +830,7 @@ impl<'addr, 'bufs, 'control> MsgHdrInit<'addr, 'bufs, 'control> {
         // SAFETY: all zero is valid for `msghdr` and `WSAMSG`.
         MsgHdrInit {
             inner: unsafe { mem::zeroed() },
+            src: None,
             _lifetimes: PhantomData,
         }
     }
@@ -830,6 +842,7 @@ impl<'addr, 'bufs, 'control> MsgHdrInit<'addr, 'bufs, 'control> {
     #[allow(clippy::needless_pass_by_ref_mut)]
     pub fn with_addr(mut self, addr: &'addr mut SockAddr) -> Self {
         sys::set_msghdr_name(&mut self.inner, addr);
+        self.src = Some(addr);
         self
     }
 
@@ -874,6 +887,11 @@ impl<'addr, 'bufs, 'control> MsgHdrInit<'addr, 'bufs, 'control> {
         }
 
         cmsg_vec
+    }
+
+    /// Returns the optional source address in this struct.
+    pub fn get_addr(&self) -> Option<&SockAddr> {
+        self.src.as_deref()
     }
 }
 

--- a/src/sockaddr.rs
+++ b/src/sockaddr.rs
@@ -143,10 +143,11 @@ impl SockAddr {
         })
     }
 
-    /// Create an empty `SockAddr` with address storage initialzed with zeros, and
-    /// `len` set to the full length of the address storage.
+    /// Create an empty `SockAddr` with the address storage initialzed with zeros, and
+    /// its `len` set to the full length of the address storage.
     ///
-    /// This is a convenient method to create a valid `SockAddr` to be filled in.
+    /// This is a convenient method to create a valid `SockAddr` to be filled in as any
+    /// kind of socket addresses (e.g. IPv4 or IPv6).
     pub fn empty() -> SockAddr {
         // SAFETY: a `sockaddr_storage` of all zeros is valid.
         let storage = unsafe { mem::zeroed::<sockaddr_storage>() };

--- a/src/sockaddr.rs
+++ b/src/sockaddr.rs
@@ -184,11 +184,6 @@ impl SockAddr {
         Domain(self.storage.ss_family as c_int)
     }
 
-    /// Returns the length in socket storage.
-    pub const fn ss_len(&self) -> socklen_t {
-        self.storage.ss_len as socklen_t
-    }
-
     /// Returns the size of this address in bytes.
     pub const fn len(&self) -> socklen_t {
         self.len

--- a/src/sockaddr.rs
+++ b/src/sockaddr.rs
@@ -143,6 +143,17 @@ impl SockAddr {
         })
     }
 
+    /// Create an empty `SockAddr` with address storage initialzed with zeros, and
+    /// `len` set to the full length of the address storage.
+    ///
+    /// This is a convenient method to create a valid `SockAddr` to be filled in.
+    pub fn empty() -> SockAddr {
+        // SAFETY: a `sockaddr_storage` of all zeros is valid.
+        let storage = unsafe { mem::zeroed::<sockaddr_storage>() };
+        let len = size_of::<sockaddr_storage>() as socklen_t;
+        SockAddr { storage, len }
+    }
+
     /// Constructs a `SockAddr` with the family `AF_UNIX` and the provided path.
     ///
     /// Returns an error if the path is longer than `SUN_LEN`.
@@ -171,6 +182,11 @@ impl SockAddr {
     /// Returns this address's `Domain`.
     pub const fn domain(&self) -> Domain {
         Domain(self.storage.ss_family as c_int)
+    }
+
+    /// Returns the length in socket storage.
+    pub const fn ss_len(&self) -> socklen_t {
+        self.storage.ss_len as socklen_t
     }
 
     /// Returns the size of this address in bytes.

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -719,6 +719,12 @@ impl Socket {
             return Err(io::Error::last_os_error());
         }
 
+        if let Some(src) = msg.src.as_mut() {
+            unsafe {
+                src.set_length(msg.inner.namelen as sys::socklen_t);
+            }
+        }
+
         Ok(read_bytes as usize)
     }
 

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -720,6 +720,7 @@ impl Socket {
         }
 
         if let Some(src) = msg.src.as_mut() {
+            // SAFETY: `msg.inner.namelen` has been update properly in the success case.
             unsafe {
                 src.set_length(msg.inner.namelen as sys::socklen_t);
             }

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -1161,7 +1161,7 @@ pub(crate) fn recvmsg_init(
 ) -> io::Result<usize> {
     syscall!(recvmsg(fd, &mut msg.inner, flags)).map(|length| {
         if let Some(src) = msg.src.as_mut() {
-            unsafe { src.set_length(src.ss_len()) }
+            unsafe { src.set_length(msg.inner.msg_namelen) }
         }
         length as usize
     })

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -1161,6 +1161,7 @@ pub(crate) fn recvmsg_init(
 ) -> io::Result<usize> {
     syscall!(recvmsg(fd, &mut msg.inner, flags)).map(|length| {
         if let Some(src) = msg.src.as_mut() {
+            // SAFETY: `msg.inner.msg_namelen` has been update properly in the success case.
             unsafe { src.set_length(msg.inner.msg_namelen) }
         }
         length as usize

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -1159,7 +1159,12 @@ pub(crate) fn recvmsg_init(
     msg: &mut MsgHdrInit<'_, '_, '_>,
     flags: c_int,
 ) -> io::Result<usize> {
-    syscall!(recvmsg(fd, &mut msg.inner, flags)).map(|n| n as usize)
+    syscall!(recvmsg(fd, &mut msg.inner, flags)).map(|length| {
+        if let Some(src) = msg.src.as_mut() {
+            unsafe { src.set_length(src.ss_len()) }
+        }
+        length as usize
+    })
 }
 
 #[cfg(not(any(

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -888,6 +888,11 @@ fn sent_to_recvmsg_init_v4() {
     assert!(!ip_pktinfo.is_empty());
     println!("IP PKTINFO: {:?}", ip_pktinfo);
 
+    // Verify source address from msghdr.
+    if let Some(src) = msg.get_addr() {
+        println!("source addr in msg is: {:?}", src);
+    }
+
     // Verify the data received.
     assert_eq!(received, data.len());
     let all_data = collect_io_slices(&bufs, received);


### PR DESCRIPTION
There is a subtle problem with `recvmsg_initialized` (and other `recvmsg`):  the `SockAddr` passed in via `with_addr` will not have its `len` field updated by the `recvmsg` call. 

This is because `sys::msghdr` does not store the full `SockAddr`, namely only the `sockaddr_storage` field, but not the `len` field. Hence any syscall that operates on `MsgHdrInit` will not update `addr.len`.

In this fix, we store a reference of `addr` in `MsgHdrInit` so that in `recvmsg` calls we can update the `len` field explicitly.